### PR TITLE
Added Genre support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Current available resources:
 * Movie
 * Collection
 * People
+* Genre
 
 ## Example
 
@@ -35,6 +36,7 @@ Tmdb::Movie.find("batman")
 Tmdb::Collection.find("spiderman")
 Tmdb::People.find("samuel jackson")
 Tmdb::Company.find("lucas")
+Tmdb::Genre.find("Drama")
 ```
 
 ## Search
@@ -242,3 +244,22 @@ Get the changes for a specific person id.
 ```ruby
 Tmdb::People.changes(287)
 ```
+
+### Genre
+
+```ruby
+genre = Tmdb::Genre.detail(18)
+genre.id => 18
+genre.name => "Drama"
+genre.page => 1
+genre.total_pages => 45
+genre.total_results => 883
+genre.results => [...]
+genre.get_page(page_number) => Returns next set of movies.
+```
+
+Get a list of all genres.
+```ruby
+Tmdb::Genre.list
+```
+

--- a/lib/themoviedb.rb
+++ b/lib/themoviedb.rb
@@ -5,10 +5,10 @@ require 'httparty'
   require File.join(File.dirname(__FILE__), "themoviedb", inc)
 end
 
-["movie", "collection", "people", "company"].each do |inc|
+["movie", "collection", "people", "company", "genre"].each do |inc|
   require File.join(File.dirname(__FILE__), "themoviedb", inc)
 end
 
 module Tmdb
-  VERSION = "0.0.5"
+  VERSION = "0.0.6"
 end

--- a/lib/themoviedb/genre.rb
+++ b/lib/themoviedb/genre.rb
@@ -1,0 +1,63 @@
+module Tmdb
+	class Genre
+    def initialize(attributes={})
+      attributes.each do |key, value|
+        if self.respond_to?(key.to_sym)
+          self.instance_variable_set("@#{key}", value)
+        end
+      end
+    end
+
+		#http://docs.themoviedb.apiary.io/#genres
+		@@fields = [
+			:id,
+			:page,
+			:total_pages,
+			:total_results,
+			:results
+		]
+
+		@@fields.each do |field|
+			attr_accessor field
+		end
+
+		def self.search(query)
+			self.detail(self.list['genres'].detect { |g| g['name'] == query }['id'])
+		end
+
+		class << self
+			alias_method :find, :search
+		end
+
+		def self.list
+			search = Tmdb::Search.new("/genre/list")
+			search.fetch_response
+		end
+
+		def self.detail(id, conditions={})
+			url = "/genre/#{id}/movies"
+			if !conditions.empty?
+				url << "?"
+				conditions.each_with_index do |(key, value), index|
+					url << "#{key}=#{value}"
+					if index != conditions.length - 1
+						url << "&"
+					end
+				end
+			end
+			search = Tmdb::Search.new(url)
+			self.new(search.fetch_response)
+		end
+
+		def name
+			@name ||= self.class.list['genres'].detect { |g| g['id'] == @id }['name']
+		end
+
+		def get_page(page_number, conditions={})
+			if page_number != @page and page_number > 0 and page_number <= @total_pages
+				conditions.merge!({ :page => page_number })
+				self.class.detail(id, conditions)
+			end
+		end
+	end
+end

--- a/themoviedb.gemspec
+++ b/themoviedb.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
                       "lib/themoviedb/collection.rb",
                       "lib/themoviedb/company.rb",
                       "lib/themoviedb/configuration.rb",
+                      "lib/themoviedb/genre.rb",
                       "lib/themoviedb/movie.rb",
                       "lib/themoviedb/people.rb",
                       "lib/themoviedb/resource.rb",


### PR DESCRIPTION
The MovieDB Genre endpoints are limited (there are only two of them) but they have their use. Because there is only two endpoints, I didn't have the Genre class inherit from Resource although I did pull some of the same methods out and reworked them for Genres.
