### PR TITLE
Set ETag header. Get response code and ETag.

### DIFF
--- a/lib/themoviedb/api.rb
+++ b/lib/themoviedb/api.rb
@@ -4,6 +4,7 @@ module Tmdb
     base_uri 'http://api.themoviedb.org/3/'
     format :json
     headers 'Accept' => 'application/json'
+    headers 'Content-Type' => 'application/json'
 
     def self.config
       @@config ||= {}
@@ -19,6 +20,18 @@ module Tmdb
       else
         self.config[:language] = lang
       end
+    end
+
+    def self.etag(etag)
+      headers 'If-None-Match' => '"' + etag + '"'
+    end
+
+    def self.response
+      @@response ||= {}
+    end
+
+    def self.set_response(hash)
+      @@response = hash
     end
 
   end

--- a/lib/themoviedb/search.rb
+++ b/lib/themoviedb/search.rb
@@ -48,7 +48,9 @@ module Tmdb
     #Send back whole response
     def fetch_response
       options = @params.merge(Api.config)
-      response = Api.get(@resource, :query => options, :headers => { 'Content-Type' => 'application/json', 'Accept' => 'application/json' })
+      response = Api.get(@resource, :query => options)
+      etag = response.headers['etag'].gsub /"/, ''
+      Api.set_response({'code' => response.code, 'etag' => etag})
       response.to_hash
     end
   end


### PR DESCRIPTION
This allows ETags to be set and read when making requests to the API. I tried to follow your convention for setting the ETag. For saving the response, I just stored it in a global hash in the API class. It seems some methods (i.e. detail) return the data in a different format then others (i.e. external_ids). 

An example on how this can be used with getting a TV show's detail.

Tmdb::Api.etag('06f46301d9d424db1a91a2587ba9ab36')
Tmdb::TV.detail(1396)

Then you can check the responses with:

Tmdb::Api.response['code']
Tmdb::Api.response['etag']

Open to suggestions if you have a better way to approach this.
