### PR TITLE
[issue #11]  can't bundle install due to httparty

### DIFF
--- a/themoviedb.gemspec
+++ b/themoviedb.gemspec
@@ -36,5 +36,5 @@ Gem::Specification.new do |s|
                       "spec/find_spec.rb"
                     ]
   s.require_paths = ["lib"]
-  s.add_dependency('httparty')
+  s.add_dependency('httparty', '~> 0')
 end


### PR DESCRIPTION
``` ruby
gem build themoviedb.gemspec

WARNING:  open-ended dependency on httparty (>= 0) is not recommended
 if httparty is semantically versioned, use:
   add_runtime_dependency 'httparty', '~> 0'
```
