### PR TITLE
Create private method for images response

### DIFF
--- a/lib/themoviedb/configuration.rb
+++ b/lib/themoviedb/configuration.rb
@@ -11,34 +11,40 @@ module Tmdb
     # Simply combine them all and you will have a fully qualified URL. Here’s an example URL:
     # http://cf2.imgobject.com/t/p/w500/8uO0gUM8aNqYLs1OsTBQiXu0fEv.jpg
     def base_url
-      fetch_response['images']['base_url']
+      images_config['base_url']
     end
 
     # HTTPS
     def secure_base_url
-      fetch_response['images']['secure_base_url']
+      images_config['secure_base_url']
     end
 
     def poster_sizes
-      fetch_response['images']['poster_sizes']
+      images_config['poster_sizes']
     end
 
     def backdrop_sizes
-      fetch_response['images']['backdrop_sizes']
+      images_config['backdrop_sizes']
     end
 
     def profile_sizes
-      fetch_response['images']['profile_sizes']
+      images_config['profile_sizes']
     end
 
     def logo_sizes
-      fetch_response['images']['logo_sizes']
+      images_config['logo_sizes']
     end
 
     def fetch_response
       options = @params.merge(Api.config)
       response = Api.get(@resource, :query => options)
       response.to_hash
+    end
+
+    private
+
+    def images_config
+      fetch_response['images'] || {}
     end
   end
 end


### PR DESCRIPTION
I was stubbing the responses from the tmdb API in some tests and these methods were throwing errors because the response didn't include the `images` propertiy.

This makes sure these methods don't break if the response form the API isn't as expected.
