### PR TITLE
Updates to person.rb

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,13 +379,16 @@ person = Tmdb::Person.detail(287)
 person.id => 287
 person.name => "Brad Pitt"
 person.place_of_birth => "Shawnee, Oklahoma, United States"
-person.also_known_as => []
+person.also_known_as => ["William Bradley Pitt"]
 person.adult => false
 person.biography => "From Wikipedia, the free"..
 person.birthday => "1963-12-18"
 person.deathday => ""
-person.homepage => "http://simplybrad.com/"
-person.profile_path => "w8zJQuN7tzlm6FY9mfGKihxp3Cb.jpg"
+person.homepage => ""
+person.profile_path => "/kc3M04QQAuZ9woUvH3Ju5T7ZqG5.jpg"
+person.imdb_id = > "nm0000093"
+person.popularity => "11.7667725"
+
 ```
 
 Get the list of popular people on The Movie Database. This list refreshes every day.
@@ -398,16 +401,30 @@ Get the latest person id.
 Tmdb::Person.latest
 ```
 
-Get the credits for a specific person id.
+Get the combined credits for a specific person id.
 ```ruby
 Tmdb::Person.credits(287)
 ```
-
+Get the movie credits for a specific person id.
+```ruby
+Tmdb::Person.movie_credits(287)
+```
+Get the TV credits for a specific person id.
+```ruby
+Tmdb::Person.tv_credits(287)
+```
+Get the external id's for a specific person id.
+```ruby
+Tmdb::Person.external_ids(287)
+```
 Get the images for a specific person id.
 ```ruby
 Tmdb::Person.images(287)
 ```
-
+Get the tagged images for a specific person id.
+```ruby
+Tmdb::Person.tagged_images(287)
+```
 Get the changes for a specific person id.
 ```ruby
 Tmdb::Person.changes(287)

--- a/lib/themoviedb/person.rb
+++ b/lib/themoviedb/person.rb
@@ -57,7 +57,7 @@ module Tmdb
 
     #Get external ID's for a specific person id.
     def self.external_ids(id, conditions={})
-      search = Tmdb::Search.new("/#{self.endpoints[:singular]}#{self.endpoint_id + id.to_s}/external_ids")
+      search = Tmdb::Search.new("/#{self.endpoints[:singular]}/#{self.endpoint_id + id.to_s}/external_ids")
       search.fetch_response
     end
 


### PR DESCRIPTION
When using the gem in my project I had issues with `person.credits` not displaying all credits, only movie credits. I updated the gem to include methods for `person.credits => Tmdb::Person.credits` which now queries `combined_credits`. If the credits still need to be split between movie and TV, I included `person.tv_credits => Tmdb::Person.tv_credits` which queries `/tv_credits` and `person.movie_credits => Tmdb::Person.movie_credits` which queries `/movie_credits`. While I was at it, I decided to include the other missing methods for People including:
`person.external_ids => Tmdb::Person.external_ids` which queries `/external_ids`
`person.tagged_images => Tmdb::Person.tagged_images` which queries `/tagged_images`
