### PR TITLE
Remove http:// from API url for https/http support

### DIFF
--- a/lib/themoviedb/api.rb
+++ b/lib/themoviedb/api.rb
@@ -1,7 +1,7 @@
 module Tmdb
   class Api
     include HTTParty
-    base_uri 'http://api.themoviedb.org/3/'
+    base_uri 'api.themoviedb.org/3/'
     format :json
     headers 'Accept' => 'application/json'
     headers 'Content-Type' => 'application/json'


### PR DESCRIPTION
I ran into an issue running my site under SSL with TMDB's secure_url so I just removed the protocol so it could work in either situation.