### PR TITLE
Bad/missing API key raises Tmdb::InvalidApiKeyError - fixes issue #22

### DIFF
--- a/lib/themoviedb/api.rb
+++ b/lib/themoviedb/api.rb
@@ -1,4 +1,5 @@
 module Tmdb
+  class InvalidApiKeyError < StandardError ;  end
   class Api
     include HTTParty
     base_uri 'api.themoviedb.org/3/'
@@ -32,6 +33,8 @@ module Tmdb
 
     def self.set_response(hash)
       @@response = hash
+      # Detect 401 Unauthorized error, which indicates invalid API key
+      raise Tmdb::InvalidApiKeyError if hash['code'].to_i == 401
     end
   end
 end

--- a/lib/themoviedb/search.rb
+++ b/lib/themoviedb/search.rb
@@ -16,7 +16,7 @@ module Tmdb
       self
     end
 
-    def primary_realease_year(year)
+    def primary_release_year(year)
       @params[:primary_release_year] = year.to_s
       self
     end

--- a/lib/themoviedb/version.rb
+++ b/lib/themoviedb/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Tmdb
-  VERSION = '1.0.0'.freeze
+  VERSION = '1.0.1'.freeze
 end

--- a/spec/invalid_api_key_spec.rb
+++ b/spec/invalid_api_key_spec.rb
@@ -1,0 +1,24 @@
+require 'rspec'
+require 'spec_helper'
+
+describe 'invalid API key' do
+  after(:all) { Tmdb::Api.key($VALID_API_KEY) }
+  it 'raises error for nil key' do
+    Tmdb::Api.key(nil)
+    VCR.use_cassette 'api_key/nil_key' do
+      expect { Tmdb::Movie.search('batman') }.to raise_error(Tmdb::InvalidApiKeyError)
+    end
+  end
+  it 'raises error for empty string key' do
+    Tmdb::Api.key('')
+    VCR.use_cassette 'api_key/empty_string' do
+      expect { Tmdb::Movie.search('batman') }.to raise_error(Tmdb::InvalidApiKeyError)
+    end
+  end
+  it 'raises error invalid nonempty key' do
+    Tmdb::Api.key('bad-key')
+    VCR.use_cassette 'api_key/invalid_key' do
+      expect { Tmdb::Movie.search('batman') }.to raise_error(Tmdb::InvalidApiKeyError)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,8 @@
 require_relative '../lib/themoviedb.rb'
 require 'vcr'
 
-Tmdb::Api.key('8a221fc31fcdf12a8af827465574ffc9')
+$VALID_API_KEY = '8a221fc31fcdf12a8af827465574ffc9'
+Tmdb::Api.key($VALID_API_KEY)
 
 VCR.configure do |c|
   # the directory where your cassettes will be saved

--- a/spec/vcr/api_key/empty_string.yml
+++ b/spec/vcr/api_key/empty_string.yml
@@ -1,0 +1,41 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api.themoviedb.org/3/search/movie?api_key=&query=batman
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Sun, 07 Feb 2016 19:36:58 GMT
+      Server:
+      - openresty
+      X-Ratelimit-Limit:
+      - '40'
+      X-Ratelimit-Remaining:
+      - '38'
+      X-Ratelimit-Reset:
+      - '1454873828'
+      Content-Length:
+      - '86'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status_code":7,"status_message":"Invalid API key: You must be granted
+        a valid key."}'
+    http_version: 
+  recorded_at: Sun, 07 Feb 2016 19:37:00 GMT
+recorded_with: VCR 3.0.1

--- a/spec/vcr/api_key/invalid_key.yml
+++ b/spec/vcr/api_key/invalid_key.yml
@@ -1,0 +1,41 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api.themoviedb.org/3/search/movie?api_key=bad-key&query=batman
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Sun, 07 Feb 2016 19:36:58 GMT
+      Server:
+      - openresty
+      X-Ratelimit-Limit:
+      - '40'
+      X-Ratelimit-Remaining:
+      - '37'
+      X-Ratelimit-Reset:
+      - '1454873828'
+      Content-Length:
+      - '86'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status_code":7,"status_message":"Invalid API key: You must be granted
+        a valid key."}'
+    http_version: 
+  recorded_at: Sun, 07 Feb 2016 19:37:00 GMT
+recorded_with: VCR 3.0.1

--- a/spec/vcr/api_key/nil_key.yml
+++ b/spec/vcr/api_key/nil_key.yml
@@ -1,0 +1,41 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api.themoviedb.org/3/search/movie?api_key=&query=batman
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Sun, 07 Feb 2016 19:36:58 GMT
+      Server:
+      - openresty
+      X-Ratelimit-Limit:
+      - '40'
+      X-Ratelimit-Remaining:
+      - '39'
+      X-Ratelimit-Reset:
+      - '1454873828'
+      Content-Length:
+      - '86'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status_code":7,"status_message":"Invalid API key: You must be granted
+        a valid key."}'
+    http_version: 
+  recorded_at: Sun, 07 Feb 2016 19:37:00 GMT
+recorded_with: VCR 3.0.1


### PR DESCRIPTION
New exception Tmdb::InvalidApiKeyError raised when the server returns an HTTP 401 response on any request, including specs & VCR cassettes.
In spec_helper, save the 'valid' API key in a global constant, so that the tests that check invalid key can reset the key to valid after they run.
Fixed typo `primary_realease_year` => `primary_release_year` in search.rb
Bumped gem version to 1.0.1.